### PR TITLE
Fix crashing and improve handling in editor/cheat mode

### DIFF
--- a/src/features/CraftNearbyGhostItems/control.lua
+++ b/src/features/CraftNearbyGhostItems/control.lua
@@ -23,6 +23,15 @@ local function autoCraft(player)
 	info.player_position = player.position
 
 	local reach = player.character.reach_distance
+
+	-- Limit reach distance to some sane value. Useful in cases
+	-- where mods extend reach distance (like creative/cheat mods)
+	-- beyond a value that can be safely used for bounding box
+	-- when searching for entities. Additional plus is that if
+	-- values are too high, the game will freeze up while the
+	-- search function is running.
+	reach = reach > 1000 and 1000
+
 	if info.next >= #info.ghosts then
 		local aabb = {
 			left_top = {player.position.x - reach, player.position.y - reach},
@@ -51,7 +60,10 @@ local function autoCraft(player)
 
 					local recipe = game.recipe_prototypes[stack.name]
 					local item = stack.name
-					if player.force.recipes[item] ~= nil and
+
+					if player.controller_type == defines.controllers.editor or player.cheat_mode then
+						player.insert({name=item, count=1})
+					elseif player.force.recipes[item] ~= nil and
 						((player.get_craftable_count(item) > 0 and
 							player.force.recipes[item].enabled == true)) then
 						if recipe ~= nil and recipe.allow_as_intermediate then

--- a/src/features/CraftingHotkeys/control.lua
+++ b/src/features/CraftingHotkeys/control.lua
@@ -1,5 +1,22 @@
 local craft = function(player, item, count)
-	print("craft "..count.." "..item.name)
+    print("craft "..count.." "..item.name)
+
+    -- Give items to player without crafting if in editor or cheat
+    -- mode. Fixes issue with player.get_craftable_count() function
+    -- causing crashes when in editor mode as well.
+    if player.controller_type == defines.controllers.editor or player.cheat_mode  then
+
+        -- Grant one stack of items instead of filling-up the
+        -- inventory in editor/cheat mode.
+        if count == 0 then
+            count = item.stack_size
+        end
+
+        player.insert({name=item.name, count=count})
+
+        return
+    end
+
     local found = false
     local len = 0
     local recipes = {}


### PR DESCRIPTION
The purpose of this pull request is to fix the crashes caused when using the mod in cheat or editor mods, as well as to improve how the mod handles crafting of items in those modes. The mod will now grant players items for free when in editor/cheat mode, and try to do it in slightly different way when compared to regular gameplay (to avoid things like filling-up the inventory etc).